### PR TITLE
508 collect api default sort

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,10 @@ Next Release
   `/api/scan_queue/index_package_scan/` endpoint.
   `/api/scan_queue/update_status/` is now an action on a ScannableURI.
   https://github.com/aboutcode-org/purldb/issues/504
-
+- The packages collected via the `/api/collect/` endpoint can be ordered in an
+  ascending or descending fashion on fields using the ``sort`` query parameter.
+  This parameter takes in the same fields as ``sort`` from `/api/packages/`.
+  https://github.com/aboutcode-org/purldb/issues/508
 
 v5.0.1
 ---------

--- a/docs/source/purldb/rest_api.rst
+++ b/docs/source/purldb/rest_api.rst
@@ -221,6 +221,25 @@ For example:
 
     curl -X GET "$api_url?$payload" -H "$content_type"
 
+The packages list can be ordered by the following fields:
+
+    - ``type``
+    - ``namespace``
+    - ``name``
+    - ``version``
+    - ``qualifiers``
+    - ``subpath``
+    - ``download_url``
+    - ``filename``
+    - ``size``
+    - ``release_date``
+
+To sort a field in a descending fashion, prefix the field name with ``-``.
+Packages can be sorted by multiple fields.
+
+For example:
+
+``GET /api/packages/?sort=type,-size``
 
 package details
 ^^^^^^^^^^^^^^^
@@ -866,6 +885,13 @@ package. Find all addon pipelines `here. <https://scancodeio.readthedocs.io/en/l
             "resources": "https://public.purldb.io/api/packages/4f3a57de-e367-43c6-a7f1-51633d0ecd45/resources/",
             "history": "https://public.purldb.io/api/packages/4f3a57de-e367-43c6-a7f1-51633d0ecd45/history/"
         }
+
+The ordering of the packages returned by ``/api/collect/`` can be set using the
+``sort`` query parameter.
+
+``GET /api/collect/?purl=pkg:npm/asdf@1.0.2&sort=qualifiers,-size``
+
+The same sort fields from ``/api/packages/`` is also used here.
 
 collect actions
 ---------------

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -829,7 +829,7 @@ class CollectViewSet(viewsets.ViewSet):
 
         validated_data = serializer.validated_data
         purl = validated_data.get('purl')
-        sort = validated_data.get('sort', [])
+        sort = validated_data.get('sort') or ['-version',]
 
         kwargs = dict()
         # We want this request to have high priority since the user knows the

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -850,7 +850,7 @@ class CollectViewSet(viewsets.ViewSet):
                 return Response(message, status=status.HTTP_400_BAD_REQUEST)
 
             lookups = purl_to_lookups(purl)
-            packages = Package.objects.filter(**lookups)
+            packages = Package.objects.filter(**lookups).order_by('-version')
             if packages.count() == 0:
                 message = {}
                 if errors:

--- a/packagedb/serializers.py
+++ b/packagedb/serializers.py
@@ -428,20 +428,15 @@ class CollectPackageSerializer(Serializer):
         return value
 
     def validate_addon_pipelines(self, value):
-        invalid_pipelines = [
-            pipe for pipe in value if not is_supported_addon_pipeline(pipe)]
-        if invalid_pipelines:
-            raise ValidationError(
-                f'Error unsupported addon pipelines: {",".join(invalid_pipelines)}')
-
+        if invalid_pipelines := [pipe for pipe in value if not is_supported_addon_pipeline(pipe)]:
+            raise ValidationError(f'Error unsupported addon pipelines: {",".join(invalid_pipelines)}')
         return value
 
     def validate_sort(self, value):
-        invalid_sort_fields = [field for field in value if not is_supported_sort_field(field)]
-        if invalid_sort_fields:
+        if invalid_sort_fields := [field for field in value if not is_supported_sort_field(field)]:
             raise ValidationError(f'Error unsupported sort fields: {",".join(invalid_sort_fields)}')
-
         return value
+
 
 class PackageVersSerializer(Serializer):
     purl = CharField()
@@ -544,4 +539,5 @@ def is_supported_addon_pipeline(addon_pipeline):
 
 def is_supported_sort_field(field):
     from packagedb.api import PACKAGE_FILTER_SORT_FIELDS
-    return field in PACKAGE_FILTER_SORT_FIELDS
+    # A field could have a leading `-`
+    return field.lstrip('-') in PACKAGE_FILTER_SORT_FIELDS

--- a/packagedb/tests/test_api.py
+++ b/packagedb/tests/test_api.py
@@ -878,7 +878,6 @@ class CollectApiTestCase(JsonBasedTesting, TestCase):
             'size': 100,
         }
         self.package = Package.objects.create(**self.package_data)
-        self.package.refresh_from_db()
         self.scannableuri = ScannableURI.objects.create(
             package=self.package,
             uri=self.package_download_url,
@@ -906,7 +905,6 @@ class CollectApiTestCase(JsonBasedTesting, TestCase):
             'size': 100,
         }
         self.package2 = Package.objects.create(**self.package_data2)
-        self.package2.refresh_from_db()
         self.scannableuri2 = ScannableURI.objects.create(
             package=self.package2,
             uri=self.package_download_url2,
@@ -918,6 +916,55 @@ class CollectApiTestCase(JsonBasedTesting, TestCase):
         self.scannableuri2.index_error = 'error'
         self.scan_request_date2 = timezone.now()
         self.scannableuri2.scan_request_date = self.scan_request_date2
+
+        self.package_download_url3 = 'http://clone.org/clone1.zip'
+        self.package_data3 = {
+            'type': 'pypi',
+            'namespace': '',
+            'name': 'clone',
+            'version': '1',
+            'qualifiers': '',
+            'subpath': '',
+            'download_url': self.package_download_url3,
+            'filename': 'clone1.zip',
+            'sha1': 'clone1',
+            'md5': '',
+            'size': 100,
+        }
+        self.package3 = Package.objects.create(**self.package_data3)
+
+        self.package_download_url4 = 'http://clone.org/clone1-src.zip'
+        self.package_data4 = {
+            'type': 'pypi',
+            'namespace': '',
+            'name': 'clone',
+            'version': '1',
+            'qualifiers': 'package=src',
+            'subpath': '',
+            'download_url': self.package_download_url4,
+            'filename': 'clone1-src.zip',
+            'sha1': 'clone1-src',
+            'md5': '',
+            'size': 50,
+        }
+        self.package4 = Package.objects.create(**self.package_data4)
+
+        self.package_download_url5 = 'http://clone.org/clone1-all.zip'
+        self.package_data5 = {
+            'type': 'pypi',
+            'namespace': '',
+            'name': 'clone',
+            'version': '1',
+            'qualifiers': 'package=all',
+            'subpath': '',
+            'download_url': self.package_download_url5,
+            'filename': 'clone1-all.zip',
+            'sha1': 'clone1-all',
+            'md5': '',
+            'size': 25,
+        }
+        self.package5 = Package.objects.create(**self.package_data5)
+
 
     def test_package_live(self):
         purl_str = 'pkg:maven/org.apache.twill/twill-core@0.12.0'
@@ -993,6 +1040,23 @@ class CollectApiTestCase(JsonBasedTesting, TestCase):
         self.check_expected_results(
             result, expected, fields_to_remove=fields_to_remove, regen=FIXTURES_REGEN)
 
+    def test_collect_sort(self):
+        purl_str = 'pkg:pypi/clone@1'
+        response = self.client.get(f'/api/collect/?purl={purl_str}&sort=size')
+        for i, package_data in enumerate(response.data[1:], start=1):
+            prev_package_data = response.data[i-1]
+            self.assertTrue(prev_package_data['size'] < package_data['size'])
+
+        response = self.client.get(f'/api/collect/?purl={purl_str}&sort=-size')
+        for i, package_data in enumerate(response.data[1:], start=1):
+            prev_package_data = response.data[i-1]
+            self.assertTrue(prev_package_data['size'] > package_data['size'])
+
+        response = self.client.get(f'/api/collect/?purl={purl_str}&sort=-size')
+        for i, package_data in enumerate(response.data[1:], start=1):
+            prev_package_data = response.data[i-1]
+            self.assertTrue(prev_package_data['size'] > package_data['size'])
+            
     def test_package_api_index_packages_endpoint(self):
         priority_resource_uris_count = PriorityResourceURI.objects.all().count()
         self.assertEqual(0, priority_resource_uris_count)

--- a/packagedb/tests/test_api.py
+++ b/packagedb/tests/test_api.py
@@ -1052,11 +1052,6 @@ class CollectApiTestCase(JsonBasedTesting, TestCase):
             prev_package_data = response.data[i-1]
             self.assertTrue(prev_package_data['size'] > package_data['size'])
 
-        response = self.client.get(f'/api/collect/?purl={purl_str}&sort=-size')
-        for i, package_data in enumerate(response.data[1:], start=1):
-            prev_package_data = response.data[i-1]
-            self.assertTrue(prev_package_data['size'] > package_data['size'])
-            
     def test_package_api_index_packages_endpoint(self):
         priority_resource_uris_count = PriorityResourceURI.objects.all().count()
         self.assertEqual(0, priority_resource_uris_count)


### PR DESCRIPTION
This PR updates the `/api/collect/` endpoint to allow the user to order the packages returned by `/api/collect/`, in an ascending and descending fashion, by the ordering fields used at `/api/packages/` using the `sort` query parameter.