### PR TITLE
closes #540 update pearldb docs link

### DIFF
--- a/docs/source/how-to-guides/deploy_to_devel.rst
+++ b/docs/source/how-to-guides/deploy_to_devel.rst
@@ -13,7 +13,7 @@ directly or through a command line purlcli tool sub-command.
 
 .. note::
     This tutorial assumes that you have a working installation of PurlDB and MatchCode.io
-    If you don't, please refer to the `installation <../purldb/overview.html#installation>`_ page.
+    If you don't, please refer to the `installation <https://aboutcode.readthedocs.io/projects/PURLdb/en/latest/getting-started/install.html>`_ page.
 
 
 Why mapping binary back to sources?

--- a/docs/source/how-to-guides/symbols_and_strings.rst
+++ b/docs/source/how-to-guides/symbols_and_strings.rst
@@ -9,7 +9,7 @@ from codebase resources.
 
 .. note::
     This tutorial assumes that you have a working installation of PurlDB.
-    If you don't, please refer to the `installation <installation.html>`_ page.
+    If you don't, please refer to the `installation <../purldb/overview.html#installation>`_ page.
 
 
 Problem

--- a/docs/source/how-to-guides/symbols_and_strings.rst
+++ b/docs/source/how-to-guides/symbols_and_strings.rst
@@ -9,7 +9,7 @@ from codebase resources.
 
 .. note::
     This tutorial assumes that you have a working installation of PurlDB.
-    If you don't, please refer to the `installation <../purldb/overview.html#installation>`_ page.
+    If you don't, please refer to the `installation <https://aboutcode.readthedocs.io/projects/PURLdb/en/latest/getting-started/install.html>`_ page.
 
 
 Problem

--- a/docs/source/how-to-guides/symbols_and_strings.rst
+++ b/docs/source/how-to-guides/symbols_and_strings.rst
@@ -9,7 +9,7 @@ from codebase resources.
 
 .. note::
     This tutorial assumes that you have a working installation of PurlDB.
-    If you don't, please refer to the `installation <../purldb/overview.html#installation>`_ page.
+    If you don't, please refer to the `installation <installation.html>`_ page.
 
 
 Problem


### PR DESCRIPTION
Updated the link to installation page in documenatation. Previously it was leading to 404 page not found.