### PR TITLE
Fixing the problem of  Dead link in documentation.

### DIFF
--- a/docs/source/how-to-guides/deploy_to_devel.rst
+++ b/docs/source/how-to-guides/deploy_to_devel.rst
@@ -13,7 +13,7 @@ directly or through a command line purlcli tool sub-command.
 
 .. note::
     This tutorial assumes that you have a working installation of PurlDB and MatchCode.io
-    If you don't, please refer to the `installation <../purldb/overview.html#installation>`_ page.
+    If you don't, please refer to the :ref:`installation` page.
 
 
 Why mapping binary back to sources?

--- a/docs/source/how-to-guides/installation.rst
+++ b/docs/source/how-to-guides/installation.rst
@@ -1,3 +1,5 @@
+.. _installation:
+
 Installation
 ============
 

--- a/docs/source/how-to-guides/symbols_and_strings.rst
+++ b/docs/source/how-to-guides/symbols_and_strings.rst
@@ -9,7 +9,7 @@ from codebase resources.
 
 .. note::
     This tutorial assumes that you have a working installation of PurlDB.
-    If you don't, please refer to the `installation <../purldb/overview.html#installation>`_ page.
+    If you don't, please refer to the :ref:`installation`page.
 
 
 Problem

--- a/docs/source/matchcode/matchcode-pipeline.rst
+++ b/docs/source/matchcode/matchcode-pipeline.rst
@@ -4,11 +4,12 @@ Code Matching
 The aim of this tutorial is to show how to use the MatchCode.io API to perform
 code matching on an archive of files.
 
+
 .. note::
     This tutorial assumes that you have a working installation of PurlDB. If you
     don't, please refer to the `installation
-    <../purldb/overview.html#installation>`_ page.
-
+    <https://aboutcode.readthedocs.io/projects/PURLdb/en/latest/how-to-guides/installation.html>`_
+    page.
 Throughout this tutorial, we will use ``pkg:npm/deep-equal@1.0.1`` and a
 modified copy of ``index.js`` from it.
 

--- a/docs/source/matchcode/matchcode-pipeline.rst
+++ b/docs/source/matchcode/matchcode-pipeline.rst
@@ -7,9 +7,8 @@ code matching on an archive of files.
 
 .. note::
     This tutorial assumes that you have a working installation of PurlDB. If you
-    don't, please refer to the `installation
-    <https://aboutcode.readthedocs.io/projects/PURLdb/en/latest/how-to-guides/installation.html>`_
-    page.
+    don't, please refer to the :ref:`installation`page.
+    
 Throughout this tutorial, we will use ``pkg:npm/deep-equal@1.0.1`` and a
 modified copy of ``index.js`` from it.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "purldb",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "purldb",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
#540 fix. Now I fix the problem of Dead link in documentation.
![Screenshot 2024-11-05 115146](https://github.com/user-attachments/assets/e3388dfc-459b-4afd-ab81-7545e1f012f7)
