### PR TITLE
Fix error in django autoreload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -168,4 +168,4 @@ wheel==0.43.0
 wrapt==1.16.0
 XlsxWriter==3.2.0
 xmltodict==0.13.0
-zipp==3.20
+zipp==3.21.0


### PR DESCRIPTION
Fix the issue(https://github.com/aboutcode-org/purldb/issues/554) in django autoreload caused by an unhashable object in `zipp`. See https://github.com/python/importlib_metadata/issues/506 and https://github.com/jaraco/zipp/issues/126.

Fixes: https://github.com/aboutcode-org/purldb/issues/554