### PR TITLE
Fix incorrect repo name in documentation

### DIFF
--- a/docs/source/how-to-guides/installation.rst
+++ b/docs/source/how-to-guides/installation.rst
@@ -24,7 +24,7 @@ PurlDB
 
 .. code-block:: console
 
-    git clone https://github.com/aboutcode-org/scancode.io.git && cd scancode.io
+    git clone https://github.com/aboutcode-org/purldb.git && cd purldb
     make envfile
     docker compose build
 


### PR DESCRIPTION
I believe the documentation has a copy-and-paste error.