### PR TITLE
Use requirements.txt to build dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,8 @@ RUN mkdir -p /var/$APP_NAME/static/ \
 RUN mkdir -p /var/scancodeio/static/ \
  && mkdir -p /var/scancodeio/workspace/
 # Install the dependencies before the codebase COPY for proper Docker layer caching
-COPY --chown=$APP_USER:$APP_USER setup.cfg setup.py $APP_DIR/
-RUN pip install --no-cache-dir .
+COPY --chown=$APP_USER:$APP_USER setup.cfg setup.py requirements.txt $APP_DIR/
+RUN pip install --requirement requirements.txt --no-cache-dir .
 
 # Copy the codebase and set the proper permissions for the APP_USER
 COPY --chown=$APP_USER:$APP_USER . $APP_DIR


### PR DESCRIPTION
This also pins the dependencies in their desired version as specified in the dockerfile and avoids build failures due to new versions of dependencies.

Reference: https://github.com/aboutcode-org/purldb/issues/674